### PR TITLE
fix : elasticsearch에서 TourInfo로 데이터 하나 받아오는 부분 에러 해결

### DIFF
--- a/src/main/java/com/lion/BMWtour/controller/TourInfoController.java
+++ b/src/main/java/com/lion/BMWtour/controller/TourInfoController.java
@@ -1,6 +1,7 @@
 package com.lion.BMWtour.controller;
 
 import com.lion.BMWtour.entitiy.TourInfo;
+import com.lion.BMWtour.entitiy.TourInfoDto;
 import com.lion.BMWtour.service.TourInfoServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/lion/BMWtour/entitiy/TourInfo.java
+++ b/src/main/java/com/lion/BMWtour/entitiy/TourInfo.java
@@ -1,6 +1,7 @@
 package com.lion.BMWtour.entitiy;
 
 
+import com.lion.BMWtour.dto.PointDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -8,6 +9,9 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Document(indexName = "tourinfos")
@@ -23,7 +27,7 @@ public class TourInfo {
     private String title;
     @Field(type = FieldType.Text)
     private String address;
-    private GeoPoint point;
+    private List<Double> point = new ArrayList<>();
     @Field(type = FieldType.Text)
     private String summary;
     private String openTime;

--- a/src/main/java/com/lion/BMWtour/service/TourInfoServiceImpl.java
+++ b/src/main/java/com/lion/BMWtour/service/TourInfoServiceImpl.java
@@ -1,5 +1,6 @@
 package com.lion.BMWtour.service;
 
+import com.lion.BMWtour.dto.PointDto;
 import com.lion.BMWtour.entitiy.TourInfo;
 import com.lion.BMWtour.repository.TourInfoRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -170,7 +172,7 @@ public class TourInfoServiceImpl {
                     TourInfo tourInfo = TourInfo.builder()
                             .title(title)                      // name (명칭)
                             .address(address)                   // address (주소)
-                            .point(new GeoPoint(latitude, longitude))
+                            .point((List<Double>) new PointDto((double) latitude, (double) longitude))
                             .summary(summary)                   // summary (개요)
                             .openTime(openTime)              // openTime (이용시간)
                             .detailInfo(detailInfo)            // detailInfo (상세정보)


### PR DESCRIPTION
No converter found capable of converting from type [java.lang.Double] to type [org.springframework.data.elasticsearch.core.geo.GeoPoint]에러 해결 elasticsearchRepository 쪽에서 findbyid로 가져올 때 point값이 ArrayList형으로 넘어옴. 따라서 받는 entity인 TourInfo의 point 변수 타입을 List<Double> point로 변경